### PR TITLE
Modify "gen.py"

### DIFF
--- a/stream/gen.py
+++ b/stream/gen.py
@@ -137,7 +137,7 @@ class BinGen(torch.nn.Module):
             self.binary.data = self.source
         elif self.mode == "bipolar":
             self.binary.data = self.source.add(1).div(2)
-        self.binary.data = self.binary << self.width
+        self.binary.data = self.binary * (2**self.width)
         self.binary.data = self.binary.round().type(self.rtype)
         
     def forward(self):


### PR DESCRIPTION
I am using MacOS with M2 chip, with python 3.11.3, matplotlib 3.7.1, numpy 1.24.3, pytorch 2.0.1, pylfsr 1.0.7 installed. Running "test_stream_bi2uni.py" shows me the following runtime error. 

  File ".../UnarySim/test/stream/test_stream_bi2uni.py", line 96, in <module>
    test_bi2uni()
  File ".../UnarySim/test/stream/test_stream_bi2uni.py", line 54, in test_bi2uni
    iVecSource = BinGen(iVec, hwcfg, swcfg)().to(device)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../UnarySim/stream/gen.py", line 140, in __init__
    self.binary.data = self.binary << self.width
                       ~~~~~~~~~~~~^^~~~~~~~~~~~
RuntimeError: "lshift_cpu" not implemented for 'Float'.

After changing it to a multiplication of 2's power, it works without an error.  It also does not change the functionality in my opinion.